### PR TITLE
Display range of channel is overwritten when 'onlyShowChannels' in Imageformatter is activated.

### DIFF
--- a/src/main/java/de/mpg/biochem/mars/kymograph/ImageFormatter.java
+++ b/src/main/java/de/mpg/biochem/mars/kymograph/ImageFormatter.java
@@ -553,7 +553,7 @@ public class ImageFormatter {
                 if (displayRangeCtoMin.containsKey(originalChannelIndex) || displayRangeCtoMax.containsKey(originalChannelIndex)) {
                     double min = displayRangeCtoMin.getOrDefault(originalChannelIndex, newImp.getDisplayRangeMin());
                     double max = displayRangeCtoMax.getOrDefault(originalChannelIndex, newImp.getDisplayRangeMax());
-                    newImp.setDisplayRange(min, max);
+                    newImp.setDisplayRange(min, max, newChannelIndex);
                 } else {
                     // Apply auto contrast if no manual range was set
                     IJ.run(newImp, "Enhance Contrast", "saturated=0.35");


### PR DESCRIPTION
I found a bug in Imageformatter class of mars-kymograph. I have images with three channels and want to use two of them for building a montage. I used a Montagebuilder and formatted the montage using Imageformatter. Then, I extracted two channels using `onlyShowChannels` member and set the display range using `setDisplayRangeMin` or `setDisplayRangeMax` members as shown below.
```
def formatter = new ImageFormatter(scijavaContext, montage);
formatter
    .onlyShowChannels(1, 2) // not use channel 3
    .setDisplayRangeMin(1, 0)
    .setDisplayRangeMax(1, 2249)
    .setDisplayRangeMin(2, 0)
    .setDisplayRangeMax(2, 10000)
    .build();
```
After running a code, the montage was successfully built, but the display range of channel 1 is set within 0 to 10000, not 0 to 2249.
When I looked the source code, I found the problem area.
```
            for (int i = 0; i < channelIndices.length; i++) {
                int originalChannelIndex = channelIndices[i];
                int newChannelIndex = i + 1; // 1-based indexing for new channels

                newImp.setC(newChannelIndex);

                // Apply display range if specified for the original channel
                if (displayRangeCtoMin.containsKey(originalChannelIndex) || displayRangeCtoMax.containsKey(originalChannelIndex)) {
                    double min = displayRangeCtoMin.getOrDefault(originalChannelIndex, newImp.getDisplayRangeMin());
                    double max = displayRangeCtoMax.getOrDefault(originalChannelIndex, newImp.getDisplayRangeMax());
                    newImp.setDisplayRange(min, max);
                } 
```
In the `extractChannelsToNewImage` member, the display range of ImagePlus object `newImp` is set to the values given in the groovy script (`displayRangeCtoMin` and `displayRangeCtoMax`). By iterating channel index which is set to in `onlyShowChannels` in the groovy script, the display range for each channel is supposed to be set. However, using the `setDisplayRange(Double, Double)` can overwrite the display range for all channels. Therefore, in my data, the display range for channel 1 is overwritten and set to within 0 to 10000 which is the setting for channel 2. To overcome this, I used `setDisplayRange(Double min, Double max, int channel)`.