### PR TITLE
Composite kymographs of multi-channels into one

### DIFF
--- a/src/main/java/de/mpg/biochem/mars/kymograph/ImageFormatter.java
+++ b/src/main/java/de/mpg/biochem/mars/kymograph/ImageFormatter.java
@@ -553,7 +553,7 @@ public class ImageFormatter {
                 if (displayRangeCtoMin.containsKey(originalChannelIndex) || displayRangeCtoMax.containsKey(originalChannelIndex)) {
                     double min = displayRangeCtoMin.getOrDefault(originalChannelIndex, newImp.getDisplayRangeMin());
                     double max = displayRangeCtoMax.getOrDefault(originalChannelIndex, newImp.getDisplayRangeMax());
-                    newImp.setDisplayRange(min, max);
+                    newImp.setDisplayRange(min, max, newChannelIndex);
                 } else {
                     // Apply auto contrast if no manual range was set
                     IJ.run(newImp, "Enhance Contrast", "saturated=0.35");

--- a/src/main/java/de/mpg/biochem/mars/kymograph/ImageFormatter.java
+++ b/src/main/java/de/mpg/biochem/mars/kymograph/ImageFormatter.java
@@ -31,6 +31,7 @@ package de.mpg.biochem.mars.kymograph;
 
 import net.imagej.Dataset;
 
+import ij.CompositeImage;
 import ij.ImagePlus;
 import ij.IJ;
 import ij.ImageStack;
@@ -421,6 +422,7 @@ public class ImageFormatter {
         if (multipleChannelsToShow == null && singleChannelToShow == -1) {
             multipleChannelsToShow = new int[imp.getNChannels()];
             for (int c=1; c<=imp.getNChannels(); c++) multipleChannelsToShow[c - 1] = c;
+            mergedImage = extractChannelsToNewImage(multipleChannelsToShow);
         }
         mergedImage = mergedImage.resize(mergedImage.getWidth()*rescaleFactor, mergedImage.getHeight()*rescaleFactor, 1, "none");
         imp = imp.resize(imp.getWidth()*rescaleFactor, imp.getHeight()*rescaleFactor, 1, "none");
@@ -767,7 +769,10 @@ public class ImageFormatter {
         transform.translate(-bounds.x, -bounds.y);
 
         // Draw main image
-        g.drawImage(mergedImage.getBufferedImage(), horizontalMargin, verticalMargin, null);
+        if (mergedImage.getNChannels() > 1)
+            g.drawImage(generateCompositeImage(mergedImage), horizontalMargin, verticalMargin, null);
+        else
+            g.drawImage(mergedImage.getBufferedImage(), horizontalMargin, verticalMargin, null);
 
         // Draw y-axis if enabled
         if (showYAxis) paintYAxis(g, verticalMargin, verticalMargin + imp.getHeight());
@@ -814,7 +819,8 @@ public class ImageFormatter {
         boolean rightRotation = rightVerticalOrientation;
 
         // Draw main image (rotated)
-        BufferedImage originalImage = mergedImage.getBufferedImage();
+        BufferedImage originalImage = mergedImage.getNChannels() > 1
+                ? generateCompositeImage(mergedImage) : mergedImage.getBufferedImage();
         int width = originalImage.getWidth();
         int height = originalImage.getHeight();
 
@@ -904,6 +910,21 @@ public class ImageFormatter {
                 stackIndex++; // Increment for next channel position
             }
         }
+    }
+
+    /**
+     * Generate a composite image from a multi-channel image
+     */
+    private BufferedImage generateCompositeImage(ImagePlus mergedImage) {
+        CompositeImage ci = new CompositeImage(imp, CompositeImage.COMPOSITE);
+        for (int originalChannelIndex : multipleChannelsToShow) {
+            // Apply contrast and LUT settings
+            ci.setC(originalChannelIndex);
+            updateChannelColor(ci, originalChannelIndex);
+        }
+        // render to RGB image
+        ImagePlus rgbImage = ci.flatten();
+        return rgbImage.getBufferedImage();
     }
 
     /**
@@ -1111,9 +1132,7 @@ public class ImageFormatter {
             return magnitude * 2.0;
     }
 
-    public String getHtmlEncodedImage() {
-        return this.htmlEncodedImage;
-    }
+    public String getHtmlEncodedImage() { return this.htmlEncodedImage; }
 
     /**
      * Saves the image as an SVG file using Apache Batik.

--- a/src/main/java/de/mpg/biochem/mars/kymograph/ImageFormatter.java
+++ b/src/main/java/de/mpg/biochem/mars/kymograph/ImageFormatter.java
@@ -555,7 +555,7 @@ public class ImageFormatter {
                 if (displayRangeCtoMin.containsKey(originalChannelIndex) || displayRangeCtoMax.containsKey(originalChannelIndex)) {
                     double min = displayRangeCtoMin.getOrDefault(originalChannelIndex, newImp.getDisplayRangeMin());
                     double max = displayRangeCtoMax.getOrDefault(originalChannelIndex, newImp.getDisplayRangeMax());
-                    newImp.setDisplayRange(min, max, newChannelIndex);
+                    newImp.setDisplayRange(min, max);
                 } else {
                     // Apply auto contrast if no manual range was set
                     IJ.run(newImp, "Enhance Contrast", "saturated=0.35");


### PR DESCRIPTION
When I generate kymographs with multi-channels and composite them into one, the contrast setting was not properly reflected and the output appeared completely black.
For generating a composite image from an ImagePlus instance, Mars called `getBufferedImage()` and passed the buffered image to `drawImage()` method in `Graphics2D`. However, the pixel range of the buffered image is 0-256 (8-bit) although the original image is 0-65536 (16-bit). The contrast setting (min & max of display value) in the original image is not properly scaled or transferred to the buffered image. This is a reason why the output looks black.

I implemented a method to make a composite image and render it to an RGB image.
Now, the kymograph in each channel properly merged into one composite image and each contrast setting works fine.

Also, I fixed a minor issue. There is a bug that Mars does not recognize a contrast setting for each channel only when we built `ImageFormatter` without setting `onlyShowChannels`. Mars show all channels when we skipped the `onlyShowChannels`, but a contrast in the composite image gets messed up. The reason of the bug is that any method for setting `DisplayRange` is not called only when we skipped the channel setting.

The lines to set the display range exist in `extractChannelsToNewImage`, and therefore I added a line to call this method and enabled to set the display range for such a case.
In the future, I think it might be better to divide a method to set the display range from the method to extract channels.